### PR TITLE
Better BaseChatInterface + Logging

### DIFF
--- a/esbmc_ai/__about__.py
+++ b/esbmc_ai/__about__.py
@@ -1,4 +1,4 @@
 # Author: Yiannis Charalambous
 
-__version__ = "v0.4.0.post0"
+__version__ = "v0.5.0.dev6"
 __author__: str = "Yiannis Charalambous"

--- a/esbmc_ai/__main__.py
+++ b/esbmc_ai/__main__.py
@@ -31,7 +31,7 @@ from esbmc_ai.commands import (
 
 from esbmc_ai.loading_widget import LoadingWidget, create_loading_widget
 from esbmc_ai.user_chat import UserChat
-from esbmc_ai.logging import printv, printvv
+from esbmc_ai.logging import print_horizontal_line, printv, printvv
 from esbmc_ai.esbmc_util import esbmc
 from esbmc_ai.chat_response import FinishReason, ChatResponse
 from esbmc_ai.ai_models import _ai_model_names
@@ -224,6 +224,14 @@ def main() -> None:
     )
 
     parser.add_argument(
+        "-r",
+        "--raw-conversation",
+        action="store_true",
+        default=False,
+        help="Show the raw conversation at the end of a command. Good for debugging...",
+    )
+
+    parser.add_argument(
         "-a",
         "--append",
         action="store_true",
@@ -271,7 +279,7 @@ def main() -> None:
         set_main_source_file(SourceFile(args.filename, file.read()))
 
     anim.start("ESBMC is processing... Please Wait")
-    exit_code, esbmc_output, esbmc_err_output = esbmc(
+    exit_code, esbmc_output = esbmc(
         path=get_main_source_file_path(),
         esbmc_params=config.esbmc_params,
         timeout=config.verifier_timeout,
@@ -279,10 +287,9 @@ def main() -> None:
     anim.stop()
 
     # Print verbose lvl 2
-    printvv("-" * os.get_terminal_size().columns)
+    print_horizontal_line(2)
     printvv(esbmc_output)
-    printvv(esbmc_err_output)
-    printvv("-" * os.get_terminal_size().columns)
+    print_horizontal_line(2)
 
     # ESBMC will output 0 for verification success and 1 for verification
     # failed, if anything else gets thrown, it's an ESBMC error.
@@ -292,7 +299,7 @@ def main() -> None:
         sys.exit(0)
     elif exit_code != 0 and exit_code != 1:
         print(f"ESBMC exit code: {exit_code}")
-        print(f"ESBMC Output:\n\n{esbmc_err_output}")
+        print(f"ESBMC Output:\n\n{esbmc_output}")
         sys.exit(1)
 
     # Command mode: Check if command is called and call it.

--- a/esbmc_ai/base_chat_interface.py
+++ b/esbmc_ai/base_chat_interface.py
@@ -1,6 +1,7 @@
 # Author: Yiannis Charalambous
 
 from abc import abstractmethod
+from typing import Optional
 
 from langchain.base_language import BaseLanguageModel
 from langchain.schema import (
@@ -26,18 +27,15 @@ class BaseChatInterface(object):
         super().__init__()
         self.ai_model: AIModel = ai_model
         self.ai_model_agent: ChatPromptSettings = ai_model_agent
+        self._system_messages: list[BaseMessage] = list(
+            ai_model_agent.system_messages.messages
+        )
         self.messages: list[BaseMessage] = []
         self.llm: BaseLanguageModel = llm
-        self.template_values: dict[str, str] = {}
 
     @abstractmethod
     def compress_message_stack(self) -> None:
         raise NotImplementedError()
-
-    def set_template_value(self, key: str, value: str) -> None:
-        """Replaces a template key with the value provided when the chat template is
-        applied."""
-        self.template_values[key] = value
 
     def push_to_message_stack(
         self,
@@ -45,21 +43,55 @@ class BaseChatInterface(object):
     ) -> None:
         self.messages.append(message)
 
-    def send_message(self, message: str) -> ChatResponse:
-        """Sends a message to the AI model. Returns solution."""
-        self.push_to_message_stack(message=HumanMessage(content=message))
+    def apply_template_value(self, **kwargs: str) -> None:
+        """Will substitute an f-string in the message stack and system messages to
+        the provided value."""
 
-        all_messages = list(self.ai_model_agent.system_messages.messages)
-        all_messages.extend(self.messages)
+        system_message_prompts: PromptValue = self.ai_model.apply_chat_template(
+            messages=self._system_messages,
+            **kwargs,
+        )
+        self._system_messages = system_message_prompts.to_messages()
+
+        message_prompts: PromptValue = self.ai_model.apply_chat_template(
+            messages=self.messages,
+            **kwargs,
+        )
+        self.messages = message_prompts.to_messages()
+
+    def get_applied_messages(self, **kwargs: str) -> tuple[BaseMessage, ...]:
+        """Applies the f-string substituion and returns the result instead of assigning
+        it to the message stack."""
+        message_prompts: PromptValue = self.ai_model.apply_chat_template(
+            messages=self.messages,
+            **kwargs,
+        )
+        return tuple(message_prompts.to_messages())
+
+    def get_applied_system_messages(self, **kwargs: str) -> tuple[BaseMessage, ...]:
+        """Same as `get_applied_messages` but for system messages."""
+        message_prompts: PromptValue = self.ai_model.apply_chat_template(
+            messages=self._system_messages,
+            **kwargs,
+        )
+        return tuple(message_prompts.to_messages())
+
+    def send_message(self, message: Optional[str] = None) -> ChatResponse:
+        """Sends a message to the AI model. Returns solution."""
+        if message:
+            self.push_to_message_stack(message=HumanMessage(content=message))
+
+        all_messages = self._system_messages.copy()
+        all_messages.extend(self.messages.copy())
 
         # Transform message stack to ChatPromptValue: If this is a ChatLLM then the
         # function will simply be an identity function that does nothing and simply
         # returns the messages as a ChatPromptValue. If this is a text generation
         # LLM, then the function should inject the config message around the
         # conversation to make the LLM behave like a ChatLLM.
+        # Do not replace any values.
         message_prompts: PromptValue = self.ai_model.apply_chat_template(
             messages=all_messages,
-            **self.template_values,
         )
 
         response: ChatResponse

--- a/esbmc_ai/config.py
+++ b/esbmc_ai/config.py
@@ -11,7 +11,7 @@ from typing import Any, NamedTuple, Optional, Union, Sequence
 from dataclasses import dataclass
 from langchain.schema import BaseMessage
 
-from .logging import *
+from esbmc_ai.logging import printv, set_verbose
 from .ai_models import *
 from .api_key_collection import APIKeyCollection
 from .chat_response import json_to_base_messages
@@ -51,6 +51,8 @@ verifier_timeout: float = 60
 
 loading_hints: bool = False
 allow_successful: bool = False
+# Show the raw conversation after the command ends
+raw_conversation: bool = False
 
 cfg_path: str
 
@@ -474,6 +476,9 @@ def load_args(args) -> None:
         else:
             print(f"Error: invalid --ai-model parameter {args.ai_model}")
             sys.exit(4)
+
+    global raw_conversation
+    raw_conversation = args.raw_conversation
 
     global esbmc_params
     # If append flag is set, then append.

--- a/esbmc_ai/esbmc_util.py
+++ b/esbmc_ai/esbmc_util.py
@@ -94,12 +94,8 @@ def esbmc(path: str, esbmc_params: list, timeout: Optional[float] = None):
         timeout=process_timeout,
     )
 
-    output_bytes: bytes = process.stdout
-    err_bytes: bytes = process.stderr
-    output: str = str(output_bytes).replace("\\n", "\n")
-    err: str = str(err_bytes).replace("\\n", "\n")
-
-    return process.returncode, output, err
+    output: str = process.stdout.decode("utf-8")
+    return process.returncode, output
 
 
 def esbmc_load_source_code(

--- a/esbmc_ai/logging.py
+++ b/esbmc_ai/logging.py
@@ -2,28 +2,42 @@
 
 """Logging module for verbose printing."""
 
-verbose: int = 0
+from os import get_terminal_size
+
+_verbose: int = 0
+
+
+def get_verbose_level() -> int:
+    return _verbose
 
 
 def set_verbose(level: int) -> None:
     """Sets the verbosity level."""
-    global verbose
-    verbose = level
+    global _verbose
+    _verbose = level
 
 
 def printv(m) -> None:
     """Level 1 verbose printing."""
-    if verbose > 0:
+    if _verbose > 0:
         print(m)
 
 
 def printvv(m) -> None:
     """Level 2 verbose printing."""
-    if verbose > 1:
+    if _verbose > 1:
         print(m)
 
 
 def printvvv(m) -> None:
     """Level 3 verbose printing."""
-    if verbose > 2:
+    if _verbose > 2:
         print(m)
+
+
+def print_horizontal_line(verbosity: int) -> None:
+    if verbosity >= _verbose:
+        try:
+            printvv("-" * get_terminal_size().columns)
+        except OSError:
+            pass

--- a/esbmc_ai/solution_generator.py
+++ b/esbmc_ai/solution_generator.py
@@ -1,9 +1,10 @@
 # Author: Yiannis Charalambous 2023
 
+from re import S
 from typing import Optional
 from typing_extensions import override
 from langchain.base_language import BaseLanguageModel
-from langchain.schema import BaseMessage
+from langchain.schema import BaseMessage, HumanMessage
 
 from esbmc_ai.chat_response import ChatResponse, FinishReason
 from esbmc_ai.config import ChatPromptSettings, DynamicAIModelAgent
@@ -86,14 +87,17 @@ class SolutionGenerator(BaseChatInterface):
 
         self.source_code_format: str = source_code_format
         self.source_code_raw: str = source_code
-        self.source_code = get_source_code_formatted(
+
+        source_code_formatted: str = get_source_code_formatted(
             source_code_format=self.source_code_format,
             source_code=self.source_code_raw,
             esbmc_output=self.esbmc_output,
         )
 
-        self.set_template_value("source_code", self.source_code)
-        self.set_template_value("esbmc_output", self.esbmc_output)
+        self.apply_template_value(
+            source_code=source_code_formatted,
+            esbmc_output=self.esbmc_output,
+        )
 
     @override
     def compress_message_stack(self) -> None:


### PR DESCRIPTION
* Fixed output of stdout and stderr in esbmc_util. It is now being decoded correctly using `utf-8`.
* Updated logging and added method to draw horizontal line safely, now ESBMC-AI will not crash when not running in a terminal (such as redirecting output to file).
* Added showing the raw conversation at the end of the fix-code command. This is a nice quality of life feature to have for debugging purposes.
* Updated all chat interfaces to use the new in-place template value logic.