### PR TITLE
Template value substitution improvements and fix code mode bug fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
 echo "Building ESBMC-AI"
-python3 -m build
+# python3 -m build
+hatch build
 

--- a/esbmc_ai/__about__.py
+++ b/esbmc_ai/__about__.py
@@ -1,4 +1,4 @@
 # Author: Yiannis Charalambous
 
-__version__ = "v0.5.0.dev14"
+__version__ = "v0.5.0rc0"
 __author__: str = "Yiannis Charalambous"

--- a/esbmc_ai/__about__.py
+++ b/esbmc_ai/__about__.py
@@ -1,4 +1,4 @@
 # Author: Yiannis Charalambous
 
-__version__ = "v0.5.0.dev10"
+__version__ = "v0.5.0.dev14"
 __author__: str = "Yiannis Charalambous"

--- a/esbmc_ai/__about__.py
+++ b/esbmc_ai/__about__.py
@@ -1,4 +1,4 @@
 # Author: Yiannis Charalambous
 
-__version__ = "v0.5.0.dev6"
+__version__ = "v0.5.0.dev10"
 __author__: str = "Yiannis Charalambous"

--- a/esbmc_ai/commands/fix_code_command.py
+++ b/esbmc_ai/commands/fix_code_command.py
@@ -131,7 +131,7 @@ class FixCodeCommand(ChatCommand):
                 if config.raw_conversation:
                     print_raw_conversation()
 
-                printv("ESBMC-AI Notice: Succesfully verified code")
+                printv("ESBMC-AI Notice: Successfully verified code")
 
                 return False, llm_solution
 

--- a/esbmc_ai/esbmc_util.py
+++ b/esbmc_ai/esbmc_util.py
@@ -84,7 +84,7 @@ def esbmc(path: str, esbmc_params: list, timeout: Optional[float] = None):
     esbmc_cmd.extend(["--timeout", str(timeout)])
 
     # Add slack time to process to allow verifier to timeout and end gracefully.
-    process_timeout: Optional[float] = timeout + 1 if timeout else None
+    process_timeout: Optional[float] = timeout + 10 if timeout else None
 
     # Run ESBMC and get output
     process: CompletedProcess = run(

--- a/esbmc_ai/esbmc_util.py
+++ b/esbmc_ai/esbmc_util.py
@@ -67,6 +67,25 @@ def get_source_code_err_line_idx(esbmc_output: str) -> Optional[int]:
         return None
 
 
+def get_clang_err_line(clang_output: str) -> Optional[int]:
+    """For when the code does not compile, gets the error line reported in the clang
+    output. This is useful for `esbmc_output_type single`"""
+    # TODO Test me
+    lines: list[str] = clang_output.splitlines()
+    for line in lines:
+        # Find the first line containing a filename along with error.
+        line_split: list[str] = line.split(":")
+        # Check for the filename
+        if line_split[0].endswith(".c") and " error" in line_split[3]:
+            return int(line_split[1])
+
+    return None
+
+
+def get_clang_err_line_index(clang_output: str) -> Optional[int]:
+    return get_clang_err_line(clang_output)
+
+
 def esbmc(path: str, esbmc_params: list, timeout: Optional[float] = None):
     """Exit code will be 0 if verification successful, 1 if verification
     failed. And any other number for compilation error/general errors."""

--- a/esbmc_ai/logging.py
+++ b/esbmc_ai/logging.py
@@ -36,8 +36,8 @@ def printvvv(m) -> None:
 
 
 def print_horizontal_line(verbosity: int) -> None:
-    if verbosity >= _verbose:
+    if _verbose >= verbosity:
         try:
-            printvv("-" * get_terminal_size().columns)
+            print("-" * get_terminal_size().columns)
         except OSError:
             pass

--- a/esbmc_ai/solution_generator.py
+++ b/esbmc_ai/solution_generator.py
@@ -19,13 +19,21 @@ from esbmc_ai.esbmc_util import (
 )
 
 
+class ESBMCTimedOutException(Exception):
+    pass
+
+
+class SourceCodeParseError(Exception):
+    pass
+
+
 def get_source_code_formatted(
     source_code_format: str, source_code: str, esbmc_output: str
 ) -> str:
     match source_code_format:
         case "single":
             line: Optional[int] = get_source_code_err_line_idx(esbmc_output)
-            assert line, "error line not found in esbmc output"
+            assert line, f"error line not found in esbmc output:\n{esbmc_output}"
             # ESBMC reports errors starting from 1. To get the correct line, we need to use 0 based
             # indexing.
             return source_code.splitlines(True)[line]
@@ -38,11 +46,18 @@ def get_source_code_formatted(
 
 
 def get_esbmc_output_formatted(esbmc_output_type: str, esbmc_output: str) -> str:
+    # Check for parsing error
+    if "ERROR: PARSING ERROR" in esbmc_output:
+        # Parsing errors are usually small in nature.
+        raise SourceCodeParseError()
+    elif "ERROR: Timed out" in esbmc_output:
+        raise ESBMCTimedOutException()
+
     match esbmc_output_type:
         case "vp":
             value: Optional[str] = esbmc_get_violated_property(esbmc_output)
             if not value:
-                raise ValueError("Not found violated property.")
+                raise ValueError("Not found violated property." + esbmc_output)
             return value
         case "ce":
             value: Optional[str] = esbmc_get_counter_example(esbmc_output)
@@ -77,32 +92,29 @@ class SolutionGenerator(BaseChatInterface):
             ai_model=ai_model,
             llm=llm,
         )
+
         self.initial_prompt = ai_model_agent.initial_prompt
 
         self.esbmc_output_type: str = esbmc_output_type
-        self.esbmc_output = get_esbmc_output_formatted(
-            esbmc_output_type=self.esbmc_output_type,
-            esbmc_output=esbmc_output,
-        )
-
         self.source_code_format: str = source_code_format
         self.source_code_raw: str = source_code
+        # Used for resetting state.
+        self._original_source_code: str = source_code
 
-        source_code_formatted: str = get_source_code_formatted(
-            source_code_format=self.source_code_format,
-            source_code=self.source_code_raw,
-            esbmc_output=self.esbmc_output,
-        )
-
-        self.apply_template_value(
-            source_code=source_code_formatted,
-            esbmc_output=self.esbmc_output,
-        )
+        # Format ESBMC output
+        try:
+            self.esbmc_output = get_esbmc_output_formatted(
+                esbmc_output_type=self.esbmc_output_type,
+                esbmc_output=esbmc_output,
+            )
+        except SourceCodeParseError:
+            self.esbmc_output = esbmc_output
 
     @override
     def compress_message_stack(self) -> None:
         # Resets the conversation - cannot summarize code
         self.messages: list[BaseMessage] = []
+        self.source_code_raw = self._original_source_code
 
     @classmethod
     def get_code_from_solution(cls, solution: str) -> str:
@@ -130,7 +142,23 @@ class SolutionGenerator(BaseChatInterface):
         return solution
 
     def generate_solution(self) -> tuple[str, FinishReason]:
-        response: ChatResponse = self.send_message(self.initial_prompt)
+        self.push_to_message_stack(HumanMessage(content=self.initial_prompt))
+
+        # Format source code
+        source_code_formatted: str = get_source_code_formatted(
+            source_code_format=self.source_code_format,
+            source_code=self.source_code_raw,
+            esbmc_output=self.esbmc_output,
+        )
+
+        # Apply template substitution to message stack
+        self.apply_template_value(
+            source_code=source_code_formatted,
+            esbmc_output=self.esbmc_output,
+        )
+
+        # Generate the solution
+        response: ChatResponse = self.send_message()
         solution: str = str(response.message.content)
 
         solution = SolutionGenerator.get_code_from_solution(solution)
@@ -149,4 +177,6 @@ class SolutionGenerator(BaseChatInterface):
                     self.source_code_raw, solution, err_line, err_line
                 )
 
+        # Remember it for next cycle
+        self.source_code_raw = solution
         return solution, response.finish_reason

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,22 +65,14 @@ Issues = "https://github.com/Yiannis128/esbmc-ai/issues"
 [tool.hatch.version]
 path = "esbmc_ai/__about__.py"
 
-# [tool.hatch.build.targets.esbmc_ai]
-# ignore-vcs = true
-# include = [
-#   "/esbmc_ai/**/*.py",
-#   "/esbmc_ai_config/**/*.py",
-# ]
-# exclude = [
-#  "/.github/*",
-#  "/.vscode",
-#  "/notebooks",
-#  "/samples",
-#  "/scripts",
-#  "/tests",
-#  "/env.example",
-#  "/.gitignore"
-# ]
+[tool.hatch.build.targets.sdist]
+ignore-vcs = false
+# include = ["esbmc-ai/**/*", "pyproject.toml", "README.md"]
+# exclude = ["**/*"]
+packages = ["esbmc_ai"]
 
-# [tool.hatch.build.targets.esbmc_ai.force-include]
-# "config.json" = "esbmc_ai_config/data/config.template.json"
+[tool.hatch.build.targets.wheel]
+ignore-vcs = false
+# include = ["esbmc-ai/**/*", "pyproject.toml", "README.md"]
+# exclude = ["**/*"]
+packages = ["esbmc_ai"]

--- a/samples/threading_broken.c
+++ b/samples/threading_broken.c
@@ -1,0 +1,25 @@
+#include <pthread.h>
+#include <assert.h>
+
+int a, b;
+void __VERIFIER_atomic_acquire(void)
+{{
+    __VERIFIER_assume(a == 0);
+    a = 1;
+}
+void *c(void *arg)
+{
+    ;
+    __VERIFIER_atomic_acquire();
+    b = 1;
+    return NULL;
+}
+pthread_t d;
+int main()
+{
+    pthread_create(&d, 0, c, 0);
+    __VERIFIER_atomic_acquire();
+    if (!b)
+        assert(0);
+    return 0;
+}


### PR DESCRIPTION
The pull request introduces the following features:
* `set _template_value` now is applied in place and is not stored. Also, `initial_prompt` also undergoes this process. Previously it was only system messages.
* `get_source_code_formatted` will get the clang error line when `single` is the set option for `source_code_format`.
* Fixed bug that would crash when printing a horizontal line when ioctl device was not available. This occurred when output redirecting to a file.
* Builds now exclude unnecessary files. Builds will now include only the required files.
* Build script now uses hatch.