### PR TITLE
Fix Code Mode: Add message history customization

### DIFF
--- a/config.json
+++ b/config.json
@@ -72,6 +72,7 @@
     "generate_solution": {
       "max_attempts": 5,
       "temperature": 1.3,
+      "message_history": "normal",
       "scenarios": {
         "division by zero": {
           "system": [

--- a/esbmc_ai/commands/fix_code_command.py
+++ b/esbmc_ai/commands/fix_code_command.py
@@ -3,7 +3,6 @@
 import sys
 from typing import Any, Tuple
 from typing_extensions import override
-from langchain.schema import AIMessage, HumanMessage
 
 from esbmc_ai.chat_response import FinishReason
 

--- a/esbmc_ai/commands/fix_code_command.py
+++ b/esbmc_ai/commands/fix_code_command.py
@@ -6,6 +6,7 @@ from typing_extensions import override
 
 from esbmc_ai.chat_response import FinishReason
 from esbmc_ai.latest_state_solution_generator import LatestStateSolutionGenerator
+from esbmc_ai.reverse_order_solution_generator import ReverseOrderSolutionGenerator
 
 from .chat_command import ChatCommand
 from .. import config
@@ -95,8 +96,26 @@ class FixCodeCommand(ChatCommand):
                         source_code_format=config.source_code_format,
                         esbmc_output_type=config.esbmc_output_type,
                     )
+                case "reverse":
+                    solution_generator = ReverseOrderSolutionGenerator(
+                        ai_model_agent=config.chat_prompt_generator_mode,
+                        source_code=source_code,
+                        esbmc_output=esbmc_output,
+                        ai_model=config.ai_model,
+                        llm=config.ai_model.create_llm(
+                            api_keys=config.api_keys,
+                            temperature=config.chat_prompt_generator_mode.temperature,
+                            requests_max_tries=config.requests_max_tries,
+                            requests_timeout=config.requests_timeout,
+                        ),
+                        scenario=scenario,
+                        source_code_format=config.source_code_format,
+                        esbmc_output_type=config.esbmc_output_type,
+                    )
                 case _:
-                    raise ValueError()
+                    raise NotImplementedError(
+                        f"error: {config.fix_code_message_history} has not been implemented in the Fix Code Command"
+                    )
         except ESBMCTimedOutException:
             print("error: ESBMC has timed out...")
             sys.exit(1)

--- a/esbmc_ai/commands/fix_code_command.py
+++ b/esbmc_ai/commands/fix_code_command.py
@@ -5,6 +5,7 @@ from typing import Any, Tuple
 from typing_extensions import override
 
 from esbmc_ai.chat_response import FinishReason
+from esbmc_ai.latest_state_solution_generator import LatestStateSolutionGenerator
 
 from .chat_command import ChatCommand
 from .. import config
@@ -61,21 +62,41 @@ class FixCodeCommand(ChatCommand):
         )
 
         try:
-            solution_generator = SolutionGenerator(
-                ai_model_agent=config.chat_prompt_generator_mode,
-                source_code=source_code,
-                esbmc_output=esbmc_output,
-                ai_model=config.ai_model,
-                llm=config.ai_model.create_llm(
-                    api_keys=config.api_keys,
-                    temperature=config.chat_prompt_generator_mode.temperature,
-                    requests_max_tries=config.requests_max_tries,
-                    requests_timeout=config.requests_timeout,
-                ),
-                scenario=scenario,
-                source_code_format=config.source_code_format,
-                esbmc_output_type=config.esbmc_output_type,
-            )
+            match config.fix_code_message_history:
+                case "normal":
+                    solution_generator = SolutionGenerator(
+                        ai_model_agent=config.chat_prompt_generator_mode,
+                        source_code=source_code,
+                        esbmc_output=esbmc_output,
+                        ai_model=config.ai_model,
+                        llm=config.ai_model.create_llm(
+                            api_keys=config.api_keys,
+                            temperature=config.chat_prompt_generator_mode.temperature,
+                            requests_max_tries=config.requests_max_tries,
+                            requests_timeout=config.requests_timeout,
+                        ),
+                        scenario=scenario,
+                        source_code_format=config.source_code_format,
+                        esbmc_output_type=config.esbmc_output_type,
+                    )
+                case "latest_only":
+                    solution_generator = LatestStateSolutionGenerator(
+                        ai_model_agent=config.chat_prompt_generator_mode,
+                        source_code=source_code,
+                        esbmc_output=esbmc_output,
+                        ai_model=config.ai_model,
+                        llm=config.ai_model.create_llm(
+                            api_keys=config.api_keys,
+                            temperature=config.chat_prompt_generator_mode.temperature,
+                            requests_max_tries=config.requests_max_tries,
+                            requests_timeout=config.requests_timeout,
+                        ),
+                        scenario=scenario,
+                        source_code_format=config.source_code_format,
+                        esbmc_output_type=config.esbmc_output_type,
+                    )
+                case _:
+                    raise ValueError()
         except ESBMCTimedOutException:
             print("error: ESBMC has timed out...")
             sys.exit(1)

--- a/esbmc_ai/config.py
+++ b/esbmc_ai/config.py
@@ -58,6 +58,7 @@ raw_conversation: bool = False
 cfg_path: str
 
 
+# TODO Get rid of this class as soon as ConfigTool with the pyautoconfig
 class AIAgentConversation(NamedTuple):
     """Immutable class describing the conversation definition for an AI agent. The
     class represents the system messages of the AI agent defined and contains a load

--- a/esbmc_ai/config.py
+++ b/esbmc_ai/config.py
@@ -44,6 +44,7 @@ esbmc_output_type: str = "full"
 source_code_format: str = "full"
 
 fix_code_max_attempts: int = 5
+fix_code_message_history: str = ""
 
 requests_max_tries: int = 5
 requests_timeout: float = 60
@@ -382,6 +383,17 @@ def load_config(file_path: str) -> None:
     if esbmc_output_type not in ["full", "vp", "ce"]:
         raise Exception(
             f"ESBMC output type in the config is not valid: {esbmc_output_type}"
+        )
+
+    global fix_code_message_history
+    fix_code_message_history, _ = _load_config_value(
+        config_file=config_file["chat_modes"]["generate_solution"],
+        name="message_history",
+    )
+
+    if fix_code_message_history not in ["normal", "latest_only", "reverse"]:
+        raise ValueError(
+            f"error: fix code mode message history not valid: {fix_code_message_history}"
         )
 
     global requests_max_tries

--- a/esbmc_ai/latest_state_solution_generator.py
+++ b/esbmc_ai/latest_state_solution_generator.py
@@ -5,8 +5,6 @@ from langchain_core.messages import BaseMessage
 from esbmc_ai.solution_generator import SolutionGenerator
 from esbmc_ai.chat_response import FinishReason
 
-# TODO Test me
-
 
 class LatestStateSolutionGenerator(SolutionGenerator):
     """SolutionGenerator that only shows the latest source code and verifier

--- a/esbmc_ai/latest_state_solution_generator.py
+++ b/esbmc_ai/latest_state_solution_generator.py
@@ -5,6 +5,8 @@ from langchain_core.messages import BaseMessage
 from esbmc_ai.solution_generator import SolutionGenerator
 from esbmc_ai.chat_response import FinishReason
 
+# TODO Test me
+
 
 class LatestStateSolutionGenerator(SolutionGenerator):
     """SolutionGenerator that only shows the latest source code and verifier

--- a/esbmc_ai/latest_state_solution_generator.py
+++ b/esbmc_ai/latest_state_solution_generator.py
@@ -1,9 +1,11 @@
 # Author: Yiannis Charalambous
 
 from typing_extensions import override
-from langchain import BaseMessage
+from langchain_core.messages import BaseMessage
 from esbmc_ai.solution_generator import SolutionGenerator
 from esbmc_ai.chat_response import FinishReason
+
+# TODO Test me
 
 
 class LatestStateSolutionGenerator(SolutionGenerator):
@@ -18,6 +20,8 @@ class LatestStateSolutionGenerator(SolutionGenerator):
         messages: list[BaseMessage] = self.messages
         self.messages: list[BaseMessage] = []
         solution, finish_reason = super().generate_solution()
+        # Append last messages to the messages stack
+        messages.extend(self.messages)
         # Restore
         self.messages = messages
         return solution, finish_reason

--- a/esbmc_ai/latest_state_solution_generator.py
+++ b/esbmc_ai/latest_state_solution_generator.py
@@ -1,0 +1,23 @@
+# Author: Yiannis Charalambous
+
+from typing_extensions import override
+from langchain import BaseMessage
+from esbmc_ai.solution_generator import SolutionGenerator
+from esbmc_ai.chat_response import FinishReason
+
+
+class LatestStateSolutionGenerator(SolutionGenerator):
+    """SolutionGenerator that only shows the latest source code and verifier
+    output state."""
+
+    @override
+    def generate_solution(self) -> tuple[str, FinishReason]:
+        # Backup message stack and clear before sending base message. We want
+        # to keep the message stack intact because we will print it with
+        # print_raw_conversation.
+        messages: list[BaseMessage] = self.messages
+        self.messages: list[BaseMessage] = []
+        solution, finish_reason = super().generate_solution()
+        # Restore
+        self.messages = messages
+        return solution, finish_reason

--- a/esbmc_ai/reverse_order_solution_generator.py
+++ b/esbmc_ai/reverse_order_solution_generator.py
@@ -19,53 +19,16 @@ class ReverseOrderSolutionGenerator(SolutionGenerator):
     reverse order."""
 
     @override
-    def generate_solution(self) -> tuple[str, FinishReason]:
-        self.push_to_message_stack(
-            HumanMessage(content=self.ai_model_agent.initial_prompt)
-        )
-
-        # Format source code
-        source_code_formatted: str = get_source_code_formatted(
-            source_code_format=self.source_code_format,
-            source_code=self.source_code_raw,
-            esbmc_output=self.esbmc_output,
-        )
-
-        # Apply template substitution to message stack
-        self.apply_template_value(
-            source_code=source_code_formatted,
-            esbmc_output=self.esbmc_output,
-        )
-
+    def send_message(self, message: Optional[str] = None) -> ChatResponse:
         # Reverse the messages
         messages: list[BaseMessage] = self.messages.copy()
         self.messages.reverse()
 
-        # Generate the solution
-        response: ChatResponse = self.send_message()
+        response: ChatResponse = super().send_message(message)
 
         # Add to the reversed message the new message received by the LLM.
         messages.append(self.messages[-1])
         # Restore
         self.messages = messages
 
-        solution: str = str(response.message.content)
-
-        solution = SolutionGenerator.get_code_from_solution(solution)
-
-        # If source code passed to LLM is formatted then we need to recombine to
-        # full source code before giving to ESBMC
-        match self.source_code_format:
-            case "single":
-                # Get source code error line from esbmc output
-                line: Optional[int] = get_source_code_err_line_idx(self.esbmc_output)
-                if not line:
-                    # Check if it parses
-                    line = get_clang_err_line_index(self.esbmc_output)
-
-                assert (
-                    line
-                ), "fix code command: error line could not be found to apply brutal patch replacement"
-                solution = apply_line_patch(self.source_code_raw, solution, line, line)
-
-        return solution, response.finish_reason
+        return response

--- a/esbmc_ai/reverse_order_solution_generator.py
+++ b/esbmc_ai/reverse_order_solution_generator.py
@@ -1,9 +1,15 @@
 # Author: Yiannis Charalambous
 
-from langchain.schema import BaseMessage
+from langchain.schema import BaseMessage, HumanMessage
 from typing_extensions import override, Optional
-from esbmc_ai.solution_generator import SolutionGenerator
-from esbmc_ai.chat_response import ChatResponse
+from esbmc_ai.solution_generator import (
+    SolutionGenerator,
+    get_source_code_formatted,
+    get_source_code_err_line_idx,
+    get_clang_err_line_index,
+    apply_line_patch,
+)
+from esbmc_ai.chat_response import FinishReason, ChatResponse
 
 # TODO Test me
 

--- a/esbmc_ai/reverse_order_solution_generator.py
+++ b/esbmc_ai/reverse_order_solution_generator.py
@@ -1,0 +1,71 @@
+# Author: Yiannis Charalambous
+
+from langchain.schema import BaseMessage, HumanMessage
+from typing_extensions import override, Optional
+from esbmc_ai.solution_generator import (
+    SolutionGenerator,
+    get_source_code_formatted,
+    get_source_code_err_line_idx,
+    get_clang_err_line_index,
+    apply_line_patch,
+)
+from esbmc_ai.chat_response import FinishReason, ChatResponse
+
+# TODO Test me
+
+
+class ReverseOrderSolutionGenerator(SolutionGenerator):
+    """SolutionGenerator that shows the source code and verifier output state in
+    reverse order."""
+
+    @override
+    def generate_solution(self) -> tuple[str, FinishReason]:
+        self.push_to_message_stack(
+            HumanMessage(content=self.ai_model_agent.initial_prompt)
+        )
+
+        # Format source code
+        source_code_formatted: str = get_source_code_formatted(
+            source_code_format=self.source_code_format,
+            source_code=self.source_code_raw,
+            esbmc_output=self.esbmc_output,
+        )
+
+        # Apply template substitution to message stack
+        self.apply_template_value(
+            source_code=source_code_formatted,
+            esbmc_output=self.esbmc_output,
+        )
+
+        # Reverse the messages
+        messages: list[BaseMessage] = self.messages.copy()
+        self.messages.reverse()
+
+        # Generate the solution
+        response: ChatResponse = self.send_message()
+
+        # Add to the reversed message the new message received by the LLM.
+        messages.append(self.messages[-1])
+        # Restore
+        self.messages = messages
+
+        solution: str = str(response.message.content)
+
+        solution = SolutionGenerator.get_code_from_solution(solution)
+
+        # If source code passed to LLM is formatted then we need to recombine to
+        # full source code before giving to ESBMC
+        match self.source_code_format:
+            case "single":
+                # Get source code error line from esbmc output
+                line: Optional[int] = get_source_code_err_line_idx(self.esbmc_output)
+                if not line:
+                    # Check if it parses
+                    line = get_clang_err_line_index(self.esbmc_output)
+
+                assert (
+                    line
+                ), "fix code command: error line could not be found to apply brutal patch replacement"
+                solution = apply_line_patch(self.source_code_raw, solution, line, line)
+
+        return solution, response.finish_reason

--- a/esbmc_ai/reverse_order_solution_generator.py
+++ b/esbmc_ai/reverse_order_solution_generator.py
@@ -1,15 +1,9 @@
 # Author: Yiannis Charalambous
 
-from langchain.schema import BaseMessage, HumanMessage
+from langchain.schema import BaseMessage
 from typing_extensions import override, Optional
-from esbmc_ai.solution_generator import (
-    SolutionGenerator,
-    get_source_code_formatted,
-    get_source_code_err_line_idx,
-    get_clang_err_line_index,
-    apply_line_patch,
-)
-from esbmc_ai.chat_response import FinishReason, ChatResponse
+from esbmc_ai.solution_generator import SolutionGenerator
+from esbmc_ai.chat_response import ChatResponse
 
 # TODO Test me
 

--- a/tests/test_latest_state_solution_generator.py
+++ b/tests/test_latest_state_solution_generator.py
@@ -1,0 +1,92 @@
+# Author: Yiannis Charalambous
+
+import pytest
+
+from langchain.schema import HumanMessage, AIMessage, SystemMessage
+from langchain_community.llms.fake import FakeListLLM
+
+from esbmc_ai.ai_models import AIModel
+from esbmc_ai.config import AIAgentConversation, ChatPromptSettings
+from esbmc_ai.latest_state_solution_generator import LatestStateSolutionGenerator
+
+
+@pytest.fixture(scope="function")
+def setup_llm_model():
+    llm = FakeListLLM(
+        responses=[
+            "This is a test response",
+            "Another test response",
+            "One more!",
+        ],
+    )
+    model = AIModel("test model", 1000)
+    return llm, model
+
+
+def test_call_update_state_first(setup_llm_model) -> None:
+    llm, model = setup_llm_model
+
+    chat_settings = ChatPromptSettings(
+        system_messages=AIAgentConversation(
+            messages=(
+                SystemMessage(content="Test message 1"),
+                HumanMessage(content="Test message 2"),
+                AIMessage(content="Test message 3"),
+            ),
+        ),
+        initial_prompt="Initial test message",
+        temperature=1.0,
+    )
+
+    solution_generator = LatestStateSolutionGenerator(
+        llm=llm,
+        ai_model=model,
+        ai_model_agent=chat_settings,
+    )
+
+    with pytest.raises(AssertionError):
+        solution_generator.generate_solution()
+
+
+def test_message_stack(setup_llm_model) -> None:
+    llm, model = setup_llm_model
+
+    chat_settings = ChatPromptSettings(
+        system_messages=AIAgentConversation(
+            messages=(
+                SystemMessage(content="Test message 1"),
+                HumanMessage(content="Test message 2"),
+                AIMessage(content="Test message 3"),
+            ),
+        ),
+        initial_prompt="Initial test message",
+        temperature=1.0,
+    )
+
+    solution_generator = LatestStateSolutionGenerator(
+        llm=llm,
+        ai_model=model,
+        ai_model_agent=chat_settings,
+    )
+
+    with pytest.raises(AssertionError):
+        solution_generator.generate_solution()
+
+    solution_generator.update_state("", "")
+
+    solution, _ = solution_generator.generate_solution()
+    assert solution == llm.responses[0]
+    solution_generator.ai_model_agent.initial_prompt = "Test message 2"
+    solution, _ = solution_generator.generate_solution()
+    assert solution == llm.responses[1]
+    solution_generator.ai_model_agent.initial_prompt = "Test message 3"
+    solution, _ = solution_generator.generate_solution()
+    assert solution == llm.responses[2]
+
+    # Test history is intact
+    assert solution_generator.messages[0].content == "Initial test message"
+    assert solution_generator.messages[1].content == "This is a test response"
+    assert solution_generator.messages[2].content == "Test message 2"
+    assert solution_generator.messages[3].content == "Another test response"
+    assert solution_generator.messages[4].content == "Test message 3"
+    assert solution_generator.messages[5].content == "One more!"

--- a/tests/test_latest_state_solution_generator.py
+++ b/tests/test_latest_state_solution_generator.py
@@ -1,13 +1,11 @@
 # Author: Yiannis Charalambous
 
-from typing import Optional
 import pytest
 
 from langchain.schema import HumanMessage, AIMessage, SystemMessage
 from langchain_community.llms.fake import FakeListLLM
 
 from esbmc_ai.ai_models import AIModel
-from esbmc_ai.chat_response import ChatResponse
 from esbmc_ai.config import AIAgentConversation, ChatPromptSettings
 from esbmc_ai.latest_state_solution_generator import LatestStateSolutionGenerator
 
@@ -48,43 +46,6 @@ def test_call_update_state_first(setup_llm_model) -> None:
 
     with pytest.raises(AssertionError):
         solution_generator.generate_solution()
-
-
-def test_functionality(setup_llm_model) -> None:
-    """Test functionality to see if the latest state along with system messages
-    are passed to send_message only."""
-
-    def mocked_send_message(message: Optional[str] = None) -> ChatResponse:
-        assert len(solution_generator.messages) == 1
-        assert solution_generator.messages[0] == HumanMessage(
-            content="Initial test message"
-        )
-        return ChatResponse()
-
-    llm, model = setup_llm_model
-
-    chat_settings = ChatPromptSettings(
-        system_messages=AIAgentConversation(
-            messages=(
-                SystemMessage(content="Test message 1"),
-                HumanMessage(content="Test message 2"),
-                AIMessage(content="Test message 3"),
-            ),
-        ),
-        initial_prompt="Initial test message",
-        temperature=1.0,
-    )
-
-    solution_generator = LatestStateSolutionGenerator(
-        llm=llm,
-        ai_model=model,
-        ai_model_agent=chat_settings,
-    )
-
-    solution_generator.update_state("", "")
-
-    solution_generator.send_message = mocked_send_message
-    solution_generator.generate_solution()
 
 
 def test_message_stack(setup_llm_model) -> None:

--- a/tests/test_reverse_order_solution_generator.py
+++ b/tests/test_reverse_order_solution_generator.py
@@ -1,0 +1,92 @@
+# Author: Yiannis Charalambous
+
+import pytest
+
+from langchain.schema import HumanMessage, AIMessage, SystemMessage
+from langchain_community.llms.fake import FakeListLLM
+
+from esbmc_ai.ai_models import AIModel
+from esbmc_ai.config import AIAgentConversation, ChatPromptSettings
+from esbmc_ai.reverse_order_solution_generator import ReverseOrderSolutionGenerator
+
+
+@pytest.fixture(scope="function")
+def setup_llm_model():
+    llm = FakeListLLM(
+        responses=[
+            "This is a test response",
+            "Another test response",
+            "One more!",
+        ],
+    )
+    model = AIModel("test model", 1000)
+    return llm, model
+
+
+def test_call_update_state_first(setup_llm_model) -> None:
+    llm, model = setup_llm_model
+
+    chat_settings = ChatPromptSettings(
+        system_messages=AIAgentConversation(
+            messages=(
+                SystemMessage(content="Test message 1"),
+                HumanMessage(content="Test message 2"),
+                AIMessage(content="Test message 3"),
+            ),
+        ),
+        initial_prompt="Initial test message",
+        temperature=1.0,
+    )
+
+    solution_generator = ReverseOrderSolutionGenerator(
+        llm=llm,
+        ai_model=model,
+        ai_model_agent=chat_settings,
+    )
+
+    with pytest.raises(AssertionError):
+        solution_generator.generate_solution()
+
+
+def test_message_stack(setup_llm_model) -> None:
+    llm, model = setup_llm_model
+
+    chat_settings = ChatPromptSettings(
+        system_messages=AIAgentConversation(
+            messages=(
+                SystemMessage(content="Test message 1"),
+                HumanMessage(content="Test message 2"),
+                AIMessage(content="Test message 3"),
+            ),
+        ),
+        initial_prompt="Initial test message",
+        temperature=1.0,
+    )
+
+    solution_generator = ReverseOrderSolutionGenerator(
+        llm=llm,
+        ai_model=model,
+        ai_model_agent=chat_settings,
+    )
+
+    with pytest.raises(AssertionError):
+        solution_generator.generate_solution()
+
+    solution_generator.update_state("", "")
+
+    solution, _ = solution_generator.generate_solution()
+    assert solution == llm.responses[0]
+    solution_generator.ai_model_agent.initial_prompt = "Test message 2"
+    solution, _ = solution_generator.generate_solution()
+    assert solution == llm.responses[1]
+    solution_generator.ai_model_agent.initial_prompt = "Test message 3"
+    solution, _ = solution_generator.generate_solution()
+    assert solution == llm.responses[2]
+
+    # Test history is intact
+    assert solution_generator.messages[0].content == "Initial test message"
+    assert solution_generator.messages[1].content == "This is a test response"
+    assert solution_generator.messages[2].content == "Test message 2"
+    assert solution_generator.messages[3].content == "Another test response"
+    assert solution_generator.messages[4].content == "Test message 3"
+    assert solution_generator.messages[5].content == "One more!"


### PR DESCRIPTION
Add the ability to customize how the history of the conversation is shown to the LLM when in Fix Code Mode. The following options are added:
* Show latest code state only: Will discard the previous patches from the LLM along with the initial code and ESBMC output. Instead, will only show the last ESBMC output.
* Show patches in reverse order: Will show the earlier patches last and the later ones first. The latest patch will be shown first.

The setting can be customized through the following fields:

```
message_history: normal/latest_only/reverse
```